### PR TITLE
[server] don't crash on unhandled exceptions / errors

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -98,3 +98,11 @@ app.get("/email", async (req: Request, res: Response) => {
 app.listen(PORT, "0.0.0.0", () => {
   console.info(`lululedger listening on port ${PORT}`);
 });
+
+process
+  .on("unhandledRejection", (err) => {
+    console.error(err);
+  })
+  .on("uncaughtException", (err) => {
+    console.error(err);
+  });


### PR DESCRIPTION
sometimes our server would crash if route handlers threw errors -- one example is if user provided invalid credentials, this would bring down the entire server. define on-process exception handlers so server stays up at least