### PR TITLE
Add flow to have login link resent

### DIFF
--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -101,7 +101,7 @@ Resends a magic link email expects:
   - a valid email
 triggers a backend action to resend magic link email if email is registered
 */
-router.get(
+router.post(
   "/resend/:email",
   useShopConfig,
   async (req: RequestWithShopConfig, res: Response) => {

--- a/src/view/components/Account.tsx
+++ b/src/view/components/Account.tsx
@@ -1,16 +1,20 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Buyer } from "../../types";
 import { useSearchParams } from "react-router-dom";
 import { AccountForm } from "./AccountForm";
 import { Button, Card } from "antd";
 import { Loading } from "./Loading";
 import { AdminView } from "./AdminView";
+import { LoginForm } from "./LoginForm";
+import { ShopConfigContext } from "../contexts/ShopConfigContext";
 
 export const Account: React.FC = () => {
   const [searchParams] = useSearchParams();
   const [buyer, setBuyer] = useState<Buyer>();
   const [loading, setLoading] = useState(true);
   const [adminView, setAdminView] = useState(false);
+  const [signup, setSignup] = useState(true); // signup = false means login view
+  const shopConfig = useContext(ShopConfigContext);
   const credential = searchParams.get("credential");
 
   const getAccountInfo = async () => {
@@ -68,8 +72,25 @@ export const Account: React.FC = () => {
               </Button>
             )}
           </div>
+        ) : signup ? (
+          <>
+            <AccountForm />
+            {shopConfig?.status === "open" && (
+              <>
+                <b>Already signed up?</b> Find the login link in your email, or{" "}
+                <a onClick={() => setSignup(false)}>
+                  click here to have the login link resent to you
+                </a>
+                .
+              </>
+            )}
+          </>
         ) : (
-          <AccountForm />
+          <>
+            <LoginForm />
+            <b>Haven't signed up yet?</b>{" "}
+            <a onClick={() => setSignup(true)}>Click here to sign up.</a>
+          </>
         )}
       </Card>
     </div>

--- a/src/view/components/AccountForm.tsx
+++ b/src/view/components/AccountForm.tsx
@@ -43,7 +43,7 @@ export const AccountForm: React.FC = () => {
     if (!response.ok) {
       setAlert({
         message:
-          "Something went wrong with signing up. If you already signed up with this email address before, please check your inbox for your magic link to login.",
+          "Something went wrong with signing up. If you already signed up with this email address before, please check your inbox for your login link or click below to have it resent to you.",
         type: "error",
       });
     } else {
@@ -143,16 +143,6 @@ export const AccountForm: React.FC = () => {
             style={{ textAlign: "left" }}
           />
         </Form.Item>
-        {showAlert && (
-          <Form.Item>
-            <Alert
-              message={alert.message}
-              type={alert.type}
-              onClose={() => setShowAlert(false)}
-              closable
-            />
-          </Form.Item>
-        )}
         <Form.Item>
           <Popconfirm
             title={"Confirm sign up"}
@@ -163,6 +153,16 @@ export const AccountForm: React.FC = () => {
             <Button type="primary">Sign up</Button>
           </Popconfirm>
         </Form.Item>
+        {showAlert && (
+          <Form.Item>
+            <Alert
+              message={alert.message}
+              type={alert.type}
+              onClose={() => setShowAlert(false)}
+              closable
+            />
+          </Form.Item>
+        )}
       </Form>
     </>
   );

--- a/src/view/components/App.tsx
+++ b/src/view/components/App.tsx
@@ -234,7 +234,11 @@ const App = () => {
                   )}
                 </div>
               </div>
-              {credential ? <CartSelector {...cartProps} /> : <SignUpButton />}
+              {credential ? (
+                <CartSelector {...cartProps} />
+              ) : (
+                <SignUpButton buttonText="Sign up / Log in" />
+              )}
             </Header>
             <Content style={{}}>
               <Routes>

--- a/src/view/components/LoginForm.tsx
+++ b/src/view/components/LoginForm.tsx
@@ -1,0 +1,88 @@
+import React, { useContext, useEffect, useState } from "react";
+import { Button, Form, Input, Alert, AlertProps } from "antd";
+import { ShopConfigContext } from "../contexts/ShopConfigContext";
+
+type AlertObject = {
+  message: string;
+  type: AlertProps["type"];
+};
+
+export const LoginForm: React.FC = () => {
+  const [form] = Form.useForm();
+  const [alert, setAlert] = useState<AlertObject>({
+    message: "",
+    type: undefined,
+  });
+  const [showAlert, setShowAlert] = useState(false);
+  const [submittedSuccessfully, setSubmittedSuccessfully] = useState(false);
+  const shopConfig = useContext(ShopConfigContext);
+
+  useEffect(() => {
+    alert.message.length > 0 && alert.type
+      ? setShowAlert(true)
+      : setShowAlert(false);
+  }, [alert]);
+
+  const resendLoginLink = async (email: string) => {
+    const response = await fetch(`/auth/resend/${email}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    if (!response.ok) {
+      setAlert({
+        message:
+          "Something went wrong with resending the login link. If you didn't sign up yet, click below to go to the signup form.",
+        type: "error",
+      });
+    } else {
+      setAlert({
+        message:
+          "We have resent the login link to your email, please use that to proceed!",
+        type: "success",
+      });
+      setSubmittedSuccessfully(true);
+    }
+  };
+
+  const onSubmit = (values: { email: string }) => {
+    resendLoginLink(values.email.toLocaleLowerCase());
+  };
+
+  return (
+    <>
+      <Form
+        form={form}
+        onFinish={onSubmit}
+        style={{ margin: "auto" }}
+        layout="horizontal"
+        labelCol={{
+          span: 8,
+        }}
+        requiredMark={false}
+        disabled={submittedSuccessfully || !(shopConfig?.status === "open")}
+      >
+        <h3>Can't find your login link?</h3>
+        <Form.Item label="Contact Email" name="email">
+          <Input required />
+        </Form.Item>
+        <Form.Item>
+          <Button type="primary" htmlType="submit">
+            Resend link
+          </Button>
+        </Form.Item>
+        {showAlert && (
+          <Form.Item>
+            <Alert
+              message={alert.message}
+              type={alert.type}
+              onClose={() => setShowAlert(false)}
+              closable
+            />
+          </Form.Item>
+        )}
+      </Form>
+    </>
+  );
+};

--- a/src/view/components/SignUpButton.tsx
+++ b/src/view/components/SignUpButton.tsx
@@ -3,7 +3,9 @@ import React, { useContext } from "react";
 import { Link } from "react-router-dom";
 import { ShopConfigContext } from "../contexts/ShopConfigContext";
 
-export const SignUpButton: React.FC = () => {
+export const SignUpButton: React.FC<{
+  buttonText?: string;
+}> = ({ buttonText }) => {
   const shopConfig = useContext(ShopConfigContext);
   return (
     <Button
@@ -15,7 +17,7 @@ export const SignUpButton: React.FC = () => {
       ) : shopConfig?.status === "closed" ? (
         "This fundraiser has ended."
       ) : (
-        <Link to="/account">Sign up to order!</Link>
+        <Link to="/account">{buttonText ?? "Sign up or log in to order!"}</Link>
       )}
     </Button>
   );


### PR DESCRIPTION
Resolves #3 

- Change "Sign up to order!" button to say "Sign up / Log in" in the top bar and "Sign up or log in to order!" in other places.
- Add link to switch to the resend email flow.
- Update copy accordingly.

<img width="1728" alt="Screenshot 2025-06-07 at 4 00 04 PM" src="https://github.com/user-attachments/assets/70a243a7-7685-474d-9ca0-31b5b49f0d45" />
<img width="1728" alt="Screenshot 2025-06-07 at 3 59 30 PM" src="https://github.com/user-attachments/assets/4563e3cd-88ce-4bd0-ba43-79c1a1f28d6a" />
<img width="1728" alt="Screenshot 2025-06-07 at 3 59 45 PM" src="https://github.com/user-attachments/assets/cd543e21-9c27-4158-ae4e-1963196aa774" />
<img width="1728" alt="Screenshot 2025-06-07 at 3 59 52 PM" src="https://github.com/user-attachments/assets/1c3cd3b5-622e-4629-8a44-bc37bb1f1977" />
